### PR TITLE
Fixed typo in maven-release-plugin config

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -885,7 +885,7 @@ under the License.
           <artifactId>maven-release-plugin</artifactId>
           <version>2.5.1</version>
           <configuration>
-            <useReleaseProfiles>true</useReleaseProfiles>
+            <useReleaseProfile>true</useReleaseProfile>
             <releaseProfiles>apache-release</releaseProfiles>
             <goals>deploy</goals>
             <arguments>${arguments}</arguments>


### PR DESCRIPTION
There's no useReleaseProfiles configuration property, just singular variant (see http://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#useReleaseProfile )
