### PR TITLE
[MPOM-163] apache-rat-plugin exclude .checkstyle file

### DIFF
--- a/asf/pom.xml
+++ b/asf/pom.xml
@@ -272,6 +272,11 @@ under the License.
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <version>0.12</version>
+          <configuration>
+            <excludes>
+              <exclude>.checkstyle</exclude>
+            </excludes>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This file is created by the Eclipse Checkstyle plugin
<http://eclipse-cs.sourceforge.net> and is typically
on .gitignore, so it should be ignored by RAT.