### PR TITLE
[MPOM-209] correct jira component url.

### DIFF
--- a/asf/site-pom.xml
+++ b/asf/site-pom.xml
@@ -43,7 +43,7 @@ under the License.
   </scm>
   <issueManagement>
     <system>jira</system>
-    <url>https://issues.apache.org/jira/issues?jql=project%20%3D%20MPOM%20AND%20component%20%3D%20asf</url>
+    <url>https://issues.apache.org/jira/issues/?jql=project%20%3D%20MPOM%20AND%20component%20%3D%20asf</url>
   </issueManagement>
   <ciManagement>
     <system>Jenkins</system>

--- a/asf/site-pom.xml
+++ b/asf/site-pom.xml
@@ -43,7 +43,7 @@ under the License.
   </scm>
   <issueManagement>
     <system>jira</system>
-    <url>https://issues.apache.org/jira/browse/MPOM/component/12314370</url>
+    <url>https://issues.apache.org/jira/issues?jql=project%20%3D%20MPOM%20AND%20component%20%3D%20asf</url>
   </issueManagement>
   <ciManagement>
     <system>Jenkins</system>


### PR DESCRIPTION
The Jira URL with the component Id was not valid id so  changed it to
https://issues.apache.org/jira/issues/?jql=project%20%3D%20MPOM%20AND%20component%20%3D%20asf